### PR TITLE
Fix scribe check for apache fop 

### DIFF
--- a/lib/git-scribe/check.rb
+++ b/lib/git-scribe/check.rb
@@ -42,7 +42,7 @@ class GitScribe
 
 
       # check for fop
-      if !check_can_run('fop -version')
+      if !check_can_run('fop -v -out list')
         info "fop is not present, please install for PDF generation"
         status[:fop] = false
       else

--- a/test/check_test.rb
+++ b/test/check_test.rb
@@ -9,4 +9,15 @@ context "scribe check tests" do
     status = @scribe.check
     assert_equal status.size, 6
   end
+
+  # there no option '-version' for apache fop cli
+  # it accepts only '-v' option but doesn't exit immediately.
+  # it should be additional no-op flag provided (like '-out list')
+  #
+  # see http://svn.apache.org/repos/asf/xmlgraphics/fop/trunk/src/java/org/apache/fop/cli/CommandLineOptions.java
+  test "scribe should correctly check fop availability" do
+    assert_equal @scribe.check_can_run('fop -v -out list'), true
+    assert_equal @scribe.check_can_run('fop -v'), false
+    assert_equal @scribe.check_can_run('fop -version'), false
+  end
 end


### PR DESCRIPTION
Hi guys

Just realized that you use incorrect flag `-version` to check fop availability. There no such flag (at least in version 0.95). I use in my system (debian sid) and as far as I can see at trunk version http://svn.apache.org/repos/asf/xmlgraphics/fop/trunk/src/java/org/apache/fop/cli/CommandLineOptions.java

Also according to sources `fop` doesn't exit after version show, so you need to use some no-op command key, for example `-out list`. I've make patch with tests. Could you review and check it, please.

Thanks,
-- Sergey Avseyev
