### PR TITLE
adding dependency install documentation for osx

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -55,6 +55,11 @@ Check if you have everything installed properly for local generation with `check
     highlighting - ok
     fop      - ok
 
+If you are on OSX and using Homebrew http://mxcl.github.com/homebrew/ you can install dependencies easily:
+
+    $ brew install asciidoc source-highlight fop
+    $ brew install https://raw.github.com/adamv/homebrew-alt/master/non-free/kindlegen.rb
+
 Initialize a new book with `init`:
 
     $ git scribe init


### PR DESCRIPTION
added some documentation for getting the required dependencies on OSX using brew. pull in if you feel this is a useful addition. 
