### PR TITLE
Remove <p> tags from <li> tags.

### DIFF
--- a/lib/git-scribe/generate.rb
+++ b/lib/git-scribe/generate.rb
@@ -99,8 +99,16 @@ class GitScribe
       styledir = local('stylesheets')
       cmd = "asciidoc -a stylesdir=#{styledir} -a theme=scribe #{BOOK_FILE}"
       if ex(cmd)
+        remove_p_from_li('book.html')
         @done['html'] == true
         'book.html'
+      end
+    end
+
+    def remove_p_from_li(file)
+      content = File.read(file)
+      File.open(file, 'w') do |f|
+        f.write content.gsub(%r"<li>\s*<p>\s*(.+?)\s+</p>\s*</li>"m, '<li>\1</li>')
       end
     end
 


### PR DESCRIPTION
This is for the mobi output.  Bullet lists look terrible on the kindle -- bullet and text are on separate lines. 

I tried fixing with CSS, but it did not seem to have an effect on the kindle.

This is, admittedly, a hack, but it works -- at least on a book that is 150+ pages in PDF.  Might be better to shell out to sed, but there really does not seem to be a performance hit as-is.
