### PR TITLE
Better fixed-width font-size for Kindle viewing

### DIFF
--- a/stylesheets/scribe.css
+++ b/stylesheets/scribe.css
@@ -25,6 +25,7 @@ tt {
 	font-family:consolas, 'lucida console', 'bitstream vera sans mono',
 	           'courier new', monospace;
 	color:#000;
+  font-size: 8px;
 }
 
 p, ul, ol, dl {
@@ -78,7 +79,7 @@ h5 {
 	line-height:1.1;
 }
 
-#header { 
+#header {
 	text-align:center;
 	margin-bottom:30px;
 }


### PR DESCRIPTION
Another small fix.  The fixed width font size should be as small as possible for Kindle viewing.  Even at this size, Kindles only hold 45 characters per line.  If the font is any larger, the code samples are next to unreadable.
