### PR TITLE
Pass xslthl-config.xml path as a command line option.

### DIFF
--- a/docbook-xsl/fo.xsl
+++ b/docbook-xsl/fo.xsl
@@ -17,8 +17,6 @@
 <xsl:import href="common.xsl"/>
 
 <xsl:import href="fo/verbatim.xsl"/>
-<xsl:param name="highlight.source" select="1"></xsl:param>
-<xsl:param name="highlight.xslthl.config">file:///usr/local/Cellar/docbook/5.0/docbook/xsl/1.76.1/highlighting/xslthl-config.xml</xsl:param>
 
 <xsl:attribute-set name="monospace.verbatim.properties">
   <xsl:attribute name="keep-together.within-column">always</xsl:attribute>

--- a/lib/git-scribe/generate.rb
+++ b/lib/git-scribe/generate.rb
@@ -165,7 +165,7 @@ class GitScribe
       page_template = liquid_template('page.html')
 
       # write the index page
-      main_data = { 
+      main_data = {
         'book_title' => book_title,
         'sections' => sections
       }
@@ -175,7 +175,7 @@ class GitScribe
 
       # write the title page
       File.open('title.html', 'w+') do |f|
-        data = { 
+        data = {
           'title' => sections.first['title'],
           'sub' => sections.first['sub'],
           'prev' => {'link' => 'index.html', 'title' => "Main"},
@@ -204,7 +204,7 @@ class GitScribe
             if i <= sections.size
               next_section = sections[i+1]
             end
-            data = { 
+            data = {
               'title' => section['title'],
               'sub' => section['sub'],
               'prev' => sections[i-1],
@@ -241,7 +241,7 @@ class GitScribe
 
       source.scan(/\<h([2|3]) id=\"(.*?)\"\>(.*?)\<\/h[2|3]\>/).each do |header|
         sec = {'id' => header[1], 'name' => header[2]}
-        if header[0] == '2' 
+        if header[0] == '2'
           toc << {'section' => sec, 'subsections' => []}
         else
           toc[toc.size - 1]['subsections'] << sec
@@ -344,6 +344,7 @@ class GitScribe
     def run_xslt(jar_arguments, java_options)
       ex <<-SH
         java -cp "#{base('vendor/saxon.jar')}:#{base('vendor/xslthl-2.0.2.jar')}" \
+             -Dxslthl.config=file://"#{base('docbook-xsl/highlighting/xslthl-config.xml')}" \
              #{java_options.map { |k, v| "-D#{k}=#{v}" }.join(' ')} \
              com.icl.saxon.StyleSheet \
              #{jar_arguments}


### PR DESCRIPTION
Use the vendor-ed `./docbook-xsl/` instead of `Cellar` for the `highlighting/xslthl-config.xml` path. Less error prone...
