### PR TITLE
Fix problem with multiple generation of books that include symlinks.

### DIFF
--- a/lib/git-scribe/generate.rb
+++ b/lib/git-scribe/generate.rb
@@ -330,7 +330,7 @@ class GitScribe
     # create a new file by concatenating all the ones we find
     def gather_and_process
       files = Dir.glob("book/*")
-      FileUtils.cp_r files, 'output'
+      FileUtils.cp_r files, 'output', :remove_destination => true
     end
 
     def ex(command)

--- a/test/gen_test.rb
+++ b/test/gen_test.rb
@@ -11,6 +11,23 @@ context "scribe gen tests" do
     end
   end
 
+  test "scribe don't crash on symlinks when run twice" do
+    in_temp_dir do
+      @scribe.init('t')
+      Dir.chdir('t') do
+        FileUtils.mkdir_p 'book/includes/sub1'
+        FileUtils.mkdir_p 'book/includes/sub2'
+        FileUtils.touch 'book/includes/sub1/real_file'
+        FileUtils.ln_s '../sub1/real_file', 'book/includes/sub2/link_file'
+
+        assert_nothing_raised do
+          @scribe.gen('html')
+          @scribe.gen('html')
+        end
+      end
+    end
+  end
+
   test "scribe can generate single page html" do
     in_temp_dir do
       @scribe.init('t')


### PR DESCRIPTION
I ran into this particular problem when generating a book with node.js code -- the node_modules in particular.
