### PR TITLE
Bug fixes

### DIFF
--- a/docbook-xsl/fo.xsl
+++ b/docbook-xsl/fo.xsl
@@ -13,7 +13,7 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format">
-<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="fo/docbook.xsl"/>
 <xsl:import href="common.xsl"/>
 
 <xsl:import href="fo/verbatim.xsl"/>

--- a/lib/git-scribe/cli.rb
+++ b/lib/git-scribe/cli.rb
@@ -52,7 +52,7 @@ class GitScribe
 
       command :gen do |opts|
         opts.banner = "Usage: git scribe gen [options]"
-        opts.description = "generate digital formats"
+        opts.description = "generate digital formats: #{GitScribe::OUTPUT_TYPES.join('|')}"
       end
 
       command :check do |opts|


### PR DESCRIPTION
PDF wasn't working because docbook-xsl/fo.xml was referencing the web version of docbook. This seems to have some errors. Switched to local copy in fo.xml

Added some more text to the help output so that supported types are also displayed next to 'gen'.
